### PR TITLE
Add year shortcuts and auto-adjust month range

### DIFF
--- a/examples/demo.json
+++ b/examples/demo.json
@@ -1,4 +1,14 @@
 {
+  "monthRange": {
+    "start": {
+      "year": 2025,
+      "month": 0
+    },
+    "end": {
+      "year": 2025,
+      "month": 11
+    }
+  },
   "selectedYear": 2025,
   "dateCells": {
     "2024-11-31": {
@@ -559,5 +569,5 @@
   "selectedColorTexture": "yellow",
   "selectedView": "Linear",
   "exportDate": "2025-08-27T09:41:27.424Z",
-  "version": "2.0"
+  "version": "3.0"
 }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -9,7 +9,7 @@ import LinearView from "./views/LinearView"
 import ViewSelector from "./ViewSelector"
 
 const Calendar: React.FC = () => {
-  const { selectedYear, dateCells, setDateCells, selectedColorTexture, selectedView, setSelectedView } = useCalendar()
+  const { monthRange, dateCells, setDateCells, selectedColorTexture, selectedView, setSelectedView } = useCalendar()
 
   return (
     <div style={{ padding: "20px", fontFamily: "Arial, sans-serif" }}>
@@ -21,21 +21,21 @@ const Calendar: React.FC = () => {
 
       {selectedView === "Linear" ? (
         <LinearView
-          selectedYear={selectedYear}
+          monthRange={monthRange}
           dateCells={dateCells}
           setDateCells={setDateCells}
           selectedColorTexture={selectedColorTexture}
         />
       ) : selectedView === "Classic" ? (
         <ClassicView
-          selectedYear={selectedYear}
+          monthRange={monthRange}
           dateCells={dateCells}
           setDateCells={setDateCells}
           selectedColorTexture={selectedColorTexture}
         />
       ) : (
         <ColumnView
-          selectedYear={selectedYear}
+          monthRange={monthRange}
           dateCells={dateCells}
           setDateCells={setDateCells}
           selectedColorTexture={selectedColorTexture}

--- a/src/components/CalendarTitle.tsx
+++ b/src/components/CalendarTitle.tsx
@@ -1,18 +1,89 @@
 import React from "react"
 import { useCalendar } from "../contexts/CalendarContext"
+import { isAfter, monthPointerToValue, MonthPointer, parseMonthPointerValue } from "../utils/monthRange"
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+]
 
 const CalendarTitle: React.FC = () => {
-  const { selectedYear, setSelectedYear } = useCalendar()
+  const { monthRange, setMonthRange } = useCalendar()
   const currentYear = new Date().getFullYear()
 
-  const yearOptions = Array.from({ length: 7 }, (_, i) => currentYear - 1 + i)
+  const monthNames = MONTH_NAMES
+
+  const minYear = Math.min(currentYear - 3, monthRange.start.year, monthRange.end.year)
+  const maxYear = Math.max(currentYear + 8, monthRange.start.year, monthRange.end.year)
+
+  const monthOptions: { value: string; label: string }[] = []
+  for (let year = minYear; year <= maxYear; year++) {
+    for (let month = 0; month < 12; month++) {
+      const pointer: MonthPointer = { year, month }
+      monthOptions.push({
+        value: monthPointerToValue(pointer),
+        label: `${monthNames[month]} ${year}`,
+      })
+    }
+  }
+
+  const yearShortcutOptions: { value: string; label: string; key?: string }[] = []
+  for (let year = 2025; year <= 2030; year++) {
+    const pointer: MonthPointer = { year, month: 0 }
+    yearShortcutOptions.push({
+      value: monthPointerToValue(pointer),
+      label: `${year}`,
+      key: `year-${year}`,
+    })
+  }
+
+  const startOptions: { value: string; label: string; key?: string }[] = [
+    ...yearShortcutOptions,
+    ...monthOptions,
+  ]
+
+  const handleStartChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newStart = parseMonthPointerValue(event.target.value)
+    let newEnd = monthRange.end
+
+    if (newStart.month === 0) {
+      newEnd = { year: newStart.year, month: 11 }
+    } else if (isAfter(newStart, newEnd)) {
+      newEnd = { ...newStart }
+    }
+
+    setMonthRange({ start: newStart, end: newEnd })
+  }
+
+  const handleEndChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newEnd = parseMonthPointerValue(event.target.value)
+    let newStart = monthRange.start
+
+    if (isAfter(newStart, newEnd)) {
+      newStart = { ...newEnd }
+    }
+
+    setMonthRange({ start: newStart, end: newEnd })
+  }
+
+  const headerPrefix = "My plans from"
 
   return (
     <h1 style={{ textAlign: "center", marginBottom: "30px" }}>
-      My plans for{" "}
+      {headerPrefix}{" "}
       <select
-        value={selectedYear}
-        onChange={(e) => setSelectedYear(parseInt(e.target.value))}
+        value={monthPointerToValue(monthRange.start)}
+        onChange={handleStartChange}
         style={{
           fontSize: "inherit",
           fontWeight: "inherit",
@@ -24,9 +95,30 @@ const CalendarTitle: React.FC = () => {
           touchAction: "auto",
         }}
       >
-        {yearOptions.map((yearOption) => (
-          <option key={yearOption} value={yearOption}>
-            {yearOption}
+        {startOptions.map((option) => (
+          <option key={option.key ?? option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {" to "}
+      <select
+        value={monthPointerToValue(monthRange.end)}
+        onChange={handleEndChange}
+        style={{
+          fontSize: "inherit",
+          fontWeight: "inherit",
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          padding: "0",
+          borderRadius: "4px",
+          touchAction: "auto",
+        }}
+      >
+        {monthOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
           </option>
         ))}
       </select>

--- a/src/components/views/ClassicView.tsx
+++ b/src/components/views/ClassicView.tsx
@@ -1,16 +1,17 @@
 import { eachDayOfInterval, endOfMonth, format, getDay, startOfMonth } from "date-fns"
 import React, { useEffect, useState } from "react"
 import { applyColorToDate, ColorTextureCode, DateCellData, getDateKey, UI_COLORS } from "../../utils/colors"
+import { enumerateMonths, MonthPointer, MonthRange, monthPointerToDate } from "../../utils/monthRange"
 import Day from "../Day"
 
 interface ClassicViewProps {
-  selectedYear: number
+  monthRange: MonthRange
   dateCells: Map<string, DateCellData>
   setDateCells: (dateCells: Map<string, DateCellData>) => void
   selectedColorTexture: ColorTextureCode
 }
 
-const ClassicView: React.FC<ClassicViewProps> = ({ selectedYear, dateCells, setDateCells, selectedColorTexture }) => {
+const ClassicView: React.FC<ClassicViewProps> = ({ monthRange, dateCells, setDateCells, selectedColorTexture }) => {
   const [isDragging, setIsDragging] = useState(false)
 
   const dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -73,9 +74,10 @@ const ClassicView: React.FC<ClassicViewProps> = ({ selectedYear, dateCells, setD
     return day === 0 ? 6 : day - 1 // Sunday becomes 6, Monday becomes 0
   }
 
-  const getWeeksForMonth = (month: number): Date[][] => {
-    const startDate = startOfMonth(new Date(selectedYear, month, 1))
-    const endDate = endOfMonth(new Date(selectedYear, month, 1))
+  const getWeeksForMonth = (monthPointer: MonthPointer): Date[][] => {
+    const baseDate = monthPointerToDate(monthPointer)
+    const startDate = startOfMonth(baseDate)
+    const endDate = endOfMonth(baseDate)
 
     const allDays = eachDayOfInterval({ start: startDate, end: endDate })
     const weeks: Date[][] = []
@@ -99,11 +101,11 @@ const ClassicView: React.FC<ClassicViewProps> = ({ selectedYear, dateCells, setD
     return weeks
   }
 
-  const getMonthName = (month: number): string => {
-    return format(new Date(selectedYear, month, 1), "MMMM")
+  const getMonthName = (monthPointer: MonthPointer): string => {
+    return format(monthPointerToDate(monthPointer), "MMMM yyyy")
   }
 
-  const months = Array.from({ length: 12 }, (_, i) => i)
+  const months = enumerateMonths(monthRange)
 
   return (
     <div
@@ -123,7 +125,7 @@ const ClassicView: React.FC<ClassicViewProps> = ({ selectedYear, dateCells, setD
 
         return (
           <div
-            key={month}
+            key={`${month.year}-${month.month}`}
             style={{
               border: `2px solid ${UI_COLORS.border.primary}`,
               borderRadius: "8px",

--- a/src/components/views/ColumnView.tsx
+++ b/src/components/views/ColumnView.tsx
@@ -1,16 +1,17 @@
 import { eachDayOfInterval, endOfMonth, format, startOfMonth } from "date-fns"
 import React, { useEffect, useState } from "react"
 import { applyColorToDate, ColorTextureCode, DateCellData, getDateKey, UI_COLORS } from "../../utils/colors"
+import { enumerateMonths, MonthPointer, MonthRange, monthPointerToDate } from "../../utils/monthRange"
 import Day from "../Day"
 
 interface ColumnViewProps {
-  selectedYear: number
+  monthRange: MonthRange
   dateCells: Map<string, DateCellData>
   setDateCells: (dateCells: Map<string, DateCellData>) => void
   selectedColorTexture: ColorTextureCode
 }
 
-const ColumnView: React.FC<ColumnViewProps> = ({ selectedYear, dateCells, setDateCells, selectedColorTexture }) => {
+const ColumnView: React.FC<ColumnViewProps> = ({ monthRange, dateCells, setDateCells, selectedColorTexture }) => {
   const [isDragging, setIsDragging] = useState(false)
 
   const handleMouseDown = (date: Date) => {
@@ -66,22 +67,23 @@ const ColumnView: React.FC<ColumnViewProps> = ({ selectedYear, dateCells, setDat
     setDateCells(newDateCells)
   }
 
-  const getDaysForMonth = (month: number): Date[] => {
-    const startDate = startOfMonth(new Date(selectedYear, month, 1))
-    const endDate = endOfMonth(new Date(selectedYear, month, 1))
+  const getDaysForMonth = (monthPointer: MonthPointer): Date[] => {
+    const baseDate = monthPointerToDate(monthPointer)
+    const startDate = startOfMonth(baseDate)
+    const endDate = endOfMonth(baseDate)
     return eachDayOfInterval({ start: startDate, end: endDate })
   }
 
-  const getMonthName = (month: number): string => {
-    return format(new Date(selectedYear, month, 1), "MMMM")
+  const getMonthName = (monthPointer: MonthPointer): string => {
+    return format(monthPointerToDate(monthPointer), "MMMM yyyy")
   }
 
-  const getMaxDaysInYear = (): number => {
-    return Math.max(...Array.from({ length: 12 }, (_, i) => getDaysForMonth(i).length))
-  }
+  const months = enumerateMonths(monthRange)
 
-  const months = Array.from({ length: 12 }, (_, i) => i)
-  const maxDays = getMaxDaysInYear()
+  const getMaxDaysInRange = (): number => {
+    return Math.max(...months.map((month) => getDaysForMonth(month).length))
+  }
+  const maxDays = getMaxDaysInRange()
 
   return (
     <div
@@ -103,7 +105,7 @@ const ColumnView: React.FC<ColumnViewProps> = ({ selectedYear, dateCells, setDat
           <tr style={{ borderBottom: `2px solid ${UI_COLORS.border.primary}` }}>
             {months.map((month) => (
               <th
-                key={month}
+                key={`${month.year}-${month.month}`}
                 style={{
                   padding: "12px 8px",
                   textAlign: "center",
@@ -111,7 +113,7 @@ const ColumnView: React.FC<ColumnViewProps> = ({ selectedYear, dateCells, setDat
                   fontSize: "16px",
                   borderRight: `1px solid ${UI_COLORS.border.secondary}`,
                   backgroundColor: UI_COLORS.background.secondary,
-                  width: `${100 / 12}%`, // Equal width for all columns
+                  width: `${100 / months.length}%`,
                 }}
               >
                 {getMonthName(month)}
@@ -129,7 +131,7 @@ const ColumnView: React.FC<ColumnViewProps> = ({ selectedYear, dateCells, setDat
                 if (!day) {
                   return (
                     <td
-                      key={month}
+                      key={`${month.year}-${month.month}`}
                       style={{
                         padding: "0",
                         textAlign: "center",
@@ -150,7 +152,7 @@ const ColumnView: React.FC<ColumnViewProps> = ({ selectedYear, dateCells, setDat
 
                 return (
                   <td
-                    key={month}
+                    key={`${month.year}-${month.month}`}
                     style={{
                       padding: "0",
                       textAlign: "center",

--- a/src/components/views/LinearView.tsx
+++ b/src/components/views/LinearView.tsx
@@ -1,21 +1,20 @@
-import { addDays, eachDayOfInterval, endOfYear, format, getDay, isSameMonth, startOfYear, subDays } from "date-fns"
+import { addDays, eachDayOfInterval, format, getDay, isSameMonth, subDays } from "date-fns"
 import React, { useEffect, useState } from "react"
 import { applyColorToDate, ColorTextureCode, DateCellData, getDateKey, UI_COLORS } from "../../utils/colors"
+import { getRangeInterval, MonthRange } from "../../utils/monthRange"
 import Day from "../Day"
 
 interface LinearViewProps {
-  selectedYear: number
+  monthRange: MonthRange
   dateCells: Map<string, DateCellData>
   setDateCells: (dateCells: Map<string, DateCellData>) => void
   selectedColorTexture: ColorTextureCode
 }
 
-const LinearView: React.FC<LinearViewProps> = ({ selectedYear, dateCells, setDateCells, selectedColorTexture }) => {
+const LinearView: React.FC<LinearViewProps> = ({ monthRange, dateCells, setDateCells, selectedColorTexture }) => {
   const [isDragging, setIsDragging] = useState(false)
 
-  const year = selectedYear
-  const startDate = startOfYear(new Date(year, 0, 1))
-  const endDate = endOfYear(new Date(year, 11, 31))
+  const { start: startDate, end: endDate } = getRangeInterval(monthRange)
 
   const allDays = eachDayOfInterval({ start: startDate, end: endDate })
 
@@ -132,7 +131,16 @@ const LinearView: React.FC<LinearViewProps> = ({ selectedYear, dateCells, setDat
   }
 
   const getMonthName = (date: Date): string => {
-    return format(date, "MMMM")
+    const monthLabel = format(date, "MMMM")
+    const isStartMonth =
+      date.getFullYear() === monthRange.start.year && date.getMonth() === monthRange.start.month
+    const isJanuary = date.getMonth() === 0
+
+    if (isStartMonth || isJanuary) {
+      return `${monthLabel} ${date.getFullYear()}`
+    }
+
+    return monthLabel
   }
 
   const shouldShowMonthName = (week: Date[]): string | null => {

--- a/src/utils/monthRange.ts
+++ b/src/utils/monthRange.ts
@@ -1,0 +1,101 @@
+import { endOfMonth, startOfMonth } from "date-fns"
+
+export interface MonthPointer {
+  year: number
+  month: number // 0-based
+}
+
+export interface MonthRange {
+  start: MonthPointer
+  end: MonthPointer
+}
+
+export const isValidMonthPointer = (pointer: MonthPointer): boolean => {
+  return (
+    Number.isInteger(pointer.year) &&
+    Number.isInteger(pointer.month) &&
+    pointer.month >= 0 &&
+    pointer.month <= 11
+  )
+}
+
+export const createDefaultMonthRange = (year: number): MonthRange => ({
+  start: { year, month: 0 },
+  end: { year, month: 11 },
+})
+
+const toMonthIndex = (pointer: MonthPointer): number => pointer.year * 12 + pointer.month
+
+export const isBeforeOrEqual = (a: MonthPointer, b: MonthPointer): boolean => {
+  return toMonthIndex(a) <= toMonthIndex(b)
+}
+
+export const isAfter = (a: MonthPointer, b: MonthPointer): boolean => {
+  return toMonthIndex(a) > toMonthIndex(b)
+}
+
+export const normalizeMonthRange = (range: MonthRange): MonthRange => {
+  if (isAfter(range.start, range.end)) {
+    return {
+      start: { ...range.end },
+      end: { ...range.start },
+    }
+  }
+
+  return {
+    start: { ...range.start },
+    end: { ...range.end },
+  }
+}
+
+export const ensureValidRange = (range: MonthRange): MonthRange => {
+  const normalized = normalizeMonthRange(range)
+  return normalized
+}
+
+export const monthPointerToDate = (pointer: MonthPointer): Date => {
+  return new Date(pointer.year, pointer.month, 1)
+}
+
+export const getRangeInterval = (range: MonthRange): { start: Date; end: Date } => {
+  const normalized = normalizeMonthRange(range)
+  return {
+    start: startOfMonth(monthPointerToDate(normalized.start)),
+    end: endOfMonth(monthPointerToDate(normalized.end)),
+  }
+}
+
+export const enumerateMonths = (range: MonthRange): MonthPointer[] => {
+  const normalized = normalizeMonthRange(range)
+  const months: MonthPointer[] = []
+
+  let currentYear = normalized.start.year
+  let currentMonth = normalized.start.month
+
+  while (currentYear < normalized.end.year || (currentYear === normalized.end.year && currentMonth <= normalized.end.month)) {
+    months.push({ year: currentYear, month: currentMonth })
+    currentMonth += 1
+    if (currentMonth === 12) {
+      currentMonth = 0
+      currentYear += 1
+    }
+  }
+
+  return months
+}
+
+export const monthPointerToValue = (pointer: MonthPointer): string => {
+  return `${pointer.year}-${pointer.month}`
+}
+
+export const parseMonthPointerValue = (value: string): MonthPointer => {
+  const [yearString, monthString] = value.split("-")
+  const year = parseInt(yearString, 10)
+  const month = parseInt(monthString, 10)
+
+  if (Number.isNaN(year) || Number.isNaN(month)) {
+    throw new Error(`Invalid month pointer value: ${value}`)
+  }
+
+  return { year, month }
+}


### PR DESCRIPTION
## Summary
- add quick year-only entries to the start selector so 2025-2030 appear at the top
- when a year shortcut or any January start is chosen, automatically expand the range to that year's December

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7959432088326b553c3242ba0a144