### PR TITLE
Add shareable calendar links with multi-calendar management

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { useCalendar } from "../contexts/CalendarContext"
 import CalendarTitle from "./CalendarTitle"
+import CalendarSharingControls from "./CalendarSharingControls"
 import ColorPicker from "./ColorPicker"
 import SaveLoadData from "./SaveLoadData"
 import ClassicView from "./views/ClassicView"
@@ -15,6 +16,7 @@ const Calendar: React.FC = () => {
     <div style={{ padding: "20px", fontFamily: "Arial, sans-serif" }}>
       <CalendarTitle />
       <div className="no-print">
+        <CalendarSharingControls />
         <ColorPicker />
         <ViewSelector selectedView={selectedView} onViewChange={setSelectedView} />
       </div>

--- a/src/components/CalendarSharingControls.tsx
+++ b/src/components/CalendarSharingControls.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from "react"
+import { useCalendar } from "../contexts/CalendarContext"
+import { UI_COLORS } from "../utils/colors"
+import { encodeCalendarPayload } from "../utils/shareEncoding"
+
+const CalendarSharingControls: React.FC = () => {
+  const { currentCalendarId, availableCalendars, switchCalendar, getCurrentDataSnapshot, isInitialized } =
+    useCalendar()
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle")
+
+  if (!isInitialized || !currentCalendarId) {
+    return null
+  }
+
+  const handleShare = async () => {
+    const snapshot = getCurrentDataSnapshot()
+    if (!snapshot) return
+
+    const encoded = encodeCalendarPayload(snapshot)
+    const baseUrl = `${window.location.origin}${window.location.pathname}`
+    const shareUrl = `${baseUrl}?calendar=${currentCalendarId}&data=${encoded}`
+
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopyState("copied")
+      window.setTimeout(() => setCopyState("idle"), 2500)
+    } catch (error) {
+      console.error("Failed to copy share link:", error)
+      setCopyState("error")
+      window.prompt("Copy this calendar link", shareUrl)
+    }
+  }
+
+  const handleCalendarChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextId = event.target.value
+    if (nextId && nextId !== currentCalendarId) {
+      switchCalendar(nextId)
+    }
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "12px",
+        marginBottom: "20px",
+      }}
+    >
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          color: UI_COLORS.text.secondary,
+          fontWeight: 600,
+        }}
+      >
+        <span>Calendar</span>
+        <select
+          value={currentCalendarId}
+          onChange={handleCalendarChange}
+          style={{
+            padding: "8px 12px",
+            borderRadius: "6px",
+            border: `1px solid ${UI_COLORS.border.tertiary}`,
+            backgroundColor: UI_COLORS.background.tertiary,
+            fontSize: "14px",
+            cursor: "pointer",
+            touchAction: "auto",
+          }}
+        >
+          {availableCalendars.map((calendar) => (
+            <option key={calendar.id} value={calendar.id}>
+              {calendar.label}
+              {calendar.external ? " • shared" : " • local"}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <button
+          onClick={handleShare}
+          style={{
+            padding: "10px 18px",
+            fontSize: "14px",
+            fontWeight: "bold",
+            backgroundColor: UI_COLORS.button.primary.normal,
+            color: UI_COLORS.text.white,
+            border: "none",
+            borderRadius: "6px",
+            cursor: "pointer",
+            transition: "background-color 0.2s ease",
+            touchAction: "auto",
+          }}
+          onMouseEnter={(event) => {
+            event.currentTarget.style.backgroundColor = UI_COLORS.button.primary.hover
+          }}
+          onMouseLeave={(event) => {
+            event.currentTarget.style.backgroundColor = UI_COLORS.button.primary.normal
+          }}
+        >
+          Share calendar
+        </button>
+        {copyState === "copied" ? (
+          <span style={{ color: UI_COLORS.text.secondary, fontSize: "13px" }}>Link copied!</span>
+        ) : copyState === "error" ? (
+          <span style={{ color: UI_COLORS.button.danger.normal, fontSize: "13px" }}>Copy failed, link shown in prompt.</span>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default CalendarSharingControls

--- a/src/components/SaveLoadData.tsx
+++ b/src/components/SaveLoadData.tsx
@@ -95,28 +95,6 @@ const SaveLoadData: React.FC = () => {
           setSelectedView(loadedData.selectedView)
         }
 
-        const mergedDateCells = loadedData.dateCells
-          ? (() => {
-              const newDateCells = new Map(dateCells)
-              Object.entries(loadedData.dateCells).forEach(([dateKey, cellData]) => {
-                const existing = newDateCells.get(dateKey) || {}
-                newDateCells.set(dateKey, {
-                  ...existing,
-                  ...(cellData as any),
-                })
-              })
-              return Object.fromEntries(newDateCells)
-            })()
-          : Object.fromEntries(dateCells)
-
-        const dataToSave = {
-          monthRange: resolvedMonthRange,
-          dateCells: mergedDateCells,
-          selectedColorTexture: loadedData.selectedColorTexture || selectedColorTexture,
-          selectedView: loadedData.selectedView || selectedView,
-          version: "3.0",
-        }
-        localStorage.setItem("calendar_data", JSON.stringify(dataToSave))
       } catch (error) {
         alert("Error loading data: Invalid JSON format")
         console.error("Error parsing loaded data:", error)

--- a/src/contexts/CalendarContext.tsx
+++ b/src/contexts/CalendarContext.tsx
@@ -1,8 +1,39 @@
-import React, { createContext, useContext, useEffect, useState } from "react"
+import React, { createContext, useContext, useEffect, useRef, useState } from "react"
 import { ColorTextureCode, DateCellData } from "../utils/colors"
 import { createDefaultMonthRange, ensureValidRange, MonthRange, isValidMonthPointer } from "../utils/monthRange"
+import { decodeCalendarPayload } from "../utils/shareEncoding"
 
-type CalendarView = "Linear" | "Classic" | "Column"
+export type CalendarView = "Linear" | "Classic" | "Column"
+
+export interface StoredData {
+  monthRange: MonthRange
+  selectedYear?: number
+  dateCells: Record<string, DateCellData>
+  selectedColorTexture: ColorTextureCode
+  selectedView: CalendarView
+  version?: string
+}
+
+interface CalendarEntry {
+  id: string
+  data: StoredData
+  external: boolean
+  lastUpdated: string
+}
+
+interface CalendarRegistry {
+  currentId: string
+  localId: string
+  calendars: Record<string, CalendarEntry>
+}
+
+export interface CalendarSummary {
+  id: string
+  label: string
+  external: boolean
+  lastUpdated: string
+  isCurrent: boolean
+}
 
 interface CalendarContextType {
   monthRange: MonthRange
@@ -13,109 +44,388 @@ interface CalendarContextType {
   setSelectedColorTexture: (colorTexture: ColorTextureCode) => void
   selectedView: CalendarView
   setSelectedView: (view: CalendarView) => void
+  currentCalendarId: string | null
+  availableCalendars: CalendarSummary[]
+  switchCalendar: (calendarId: string) => void
+  isInitialized: boolean
+  getCurrentDataSnapshot: () => StoredData | null
 }
 
 const CalendarContext = createContext<CalendarContextType | undefined>(undefined)
 
-interface CalendarProviderProps {
-  children: React.ReactNode
-}
-
 const STORAGE_KEY = "calendar_data"
+const REGISTRY_STORAGE_KEY = "calendar_registry"
 const STORAGE_VERSION = "3.0"
 
-interface StoredData {
-  monthRange: MonthRange
-  selectedYear?: number
-  dateCells: Record<string, DateCellData>
-  selectedColorTexture: ColorTextureCode
-  selectedView: CalendarView
-  version?: string
+const generateCalendarId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID().replace(/-/g, "").slice(0, 12)
+  }
+  return Math.random().toString(36).slice(2, 14)
 }
 
-export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children }) => {
+const normalizeStoredData = (data: Partial<StoredData> | null | undefined, fallbackYear: number): StoredData => {
+  const defaultRange = createDefaultMonthRange(fallbackYear)
+  let monthRange = defaultRange
+
+  if (data?.monthRange && data.monthRange.start && data.monthRange.end) {
+    const { start, end } = data.monthRange
+    if (isValidMonthPointer(start) && isValidMonthPointer(end)) {
+      monthRange = ensureValidRange(data.monthRange)
+    }
+  } else if (typeof data?.selectedYear === "number") {
+    monthRange = createDefaultMonthRange(data.selectedYear)
+  }
+
+  const dateCells =
+    data?.dateCells && typeof data.dateCells === "object" ? (data.dateCells as Record<string, DateCellData>) : {}
+
+  const selectedColorTexture =
+    data?.selectedColorTexture && typeof data.selectedColorTexture === "string"
+      ? (data.selectedColorTexture as ColorTextureCode)
+      : "red"
+
+  const selectedView =
+    data?.selectedView && ["Linear", "Classic", "Column"].includes(data.selectedView)
+      ? (data.selectedView as CalendarView)
+      : "Linear"
+
+  return {
+    monthRange,
+    dateCells,
+    selectedColorTexture,
+    selectedView,
+    version: STORAGE_VERSION,
+  }
+}
+
+const parseLegacyStoredData = (raw: string | null, fallbackYear: number): StoredData | null => {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object") return null
+    return normalizeStoredData(parsed as Partial<StoredData>, fallbackYear)
+  } catch (error) {
+    console.error("Error parsing legacy calendar data:", error)
+    return null
+  }
+}
+
+const parseRegistry = (raw: string | null, fallbackYear: number): CalendarRegistry | null => {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object") {
+      return null
+    }
+
+    const localId = typeof parsed.localId === "string" && parsed.localId.trim() ? parsed.localId : generateCalendarId()
+    const calendars: Record<string, CalendarEntry> = {}
+    const nowIso = new Date().toISOString()
+
+    if (parsed.calendars && typeof parsed.calendars === "object") {
+      for (const [id, entryValue] of Object.entries(parsed.calendars as Record<string, unknown>)) {
+        if (!id || typeof entryValue !== "object" || entryValue === null) continue
+
+        const entryObject = entryValue as { data?: StoredData; external?: boolean; lastUpdated?: string }
+        const normalizedData = normalizeStoredData(entryObject.data ?? (entryObject as Partial<StoredData>), fallbackYear)
+        calendars[id] = {
+          id,
+          data: normalizedData,
+          external: Boolean(entryObject.external && id !== localId),
+          lastUpdated: typeof entryObject.lastUpdated === "string" ? entryObject.lastUpdated : nowIso,
+        }
+      }
+    }
+
+    const currentId =
+      typeof parsed.currentId === "string" && parsed.currentId in calendars ? parsed.currentId : localId
+
+    return {
+      currentId,
+      localId,
+      calendars,
+    }
+  } catch (error) {
+    console.error("Error parsing calendar registry:", error)
+    return null
+  }
+}
+
+const buildSummaries = (registry: CalendarRegistry, activeId: string): CalendarSummary[] => {
+  const entries = Object.values(registry.calendars)
+  entries.sort((a, b) => {
+    if (a.id === registry.localId && b.id !== registry.localId) return -1
+    if (a.id !== registry.localId && b.id === registry.localId) return 1
+    return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime()
+  })
+
+  return entries.map((entry) => ({
+    id: entry.id,
+    label: entry.external ? `Shared ${entry.id.slice(0, 6)}` : "My calendar",
+    external: entry.external,
+    lastUpdated: entry.lastUpdated,
+    isCurrent: entry.id === activeId,
+  }))
+}
+
+const readCalendarIdFromUrl = (): string | null => {
+  if (typeof window === "undefined") return null
+  try {
+    const url = new URL(window.location.href)
+    const calendarId = url.searchParams.get("calendar")
+    return calendarId && calendarId.trim() ? calendarId : null
+  } catch (error) {
+    console.error("Error reading calendar id from URL:", error)
+    return null
+  }
+}
+
+const parseSharedCalendarFromUrl = (fallbackYear: number): { id: string; data: StoredData } | null => {
+  if (typeof window === "undefined") return null
+
+  try {
+    const url = new URL(window.location.href)
+    const calendarId = url.searchParams.get("calendar")
+    const encodedData = url.searchParams.get("data")
+
+    if (!calendarId || !encodedData) {
+      return null
+    }
+
+    const decoded = decodeCalendarPayload(encodedData)
+    if (!decoded || typeof decoded !== "object") {
+      return null
+    }
+
+    const normalized = normalizeStoredData(decoded as Partial<StoredData>, fallbackYear)
+    return {
+      id: calendarId,
+      data: normalized,
+    }
+  } catch (error) {
+    console.error("Failed to parse shared calendar from URL:", error)
+    return null
+  }
+}
+
+export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const currentYear = new Date().getFullYear()
 
   const [monthRange, setMonthRangeState] = useState<MonthRange>(createDefaultMonthRange(currentYear))
   const [dateCells, setDateCellsState] = useState<Map<string, DateCellData>>(new Map())
   const [selectedColorTexture, setSelectedColorTextureState] = useState<ColorTextureCode>("red")
   const [selectedView, setSelectedViewState] = useState<CalendarView>("Linear")
+  const [currentCalendarId, setCurrentCalendarId] = useState<string | null>(null)
+  const [availableCalendars, setAvailableCalendars] = useState<CalendarSummary[]>([])
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  const registryRef = useRef<CalendarRegistry | null>(null)
 
   useEffect(() => {
-    try {
-      const storedData = localStorage.getItem(STORAGE_KEY)
-      if (storedData) {
-        const parsedData: StoredData = JSON.parse(storedData)
+    if (typeof window === "undefined") return
 
-        if (parsedData.monthRange) {
-          const { start, end } = parsedData.monthRange
-          if (start && end && isValidMonthPointer(start) && isValidMonthPointer(end)) {
-            setMonthRangeState(ensureValidRange(parsedData.monthRange))
-          }
-        } else if (
-          parsedData.selectedYear &&
-          parsedData.selectedYear >= currentYear - 1 &&
-          parsedData.selectedYear <= currentYear + 5
-        ) {
-          setMonthRangeState(createDefaultMonthRange(parsedData.selectedYear))
-        }
+    const fallbackYear = currentYear
+    const nowIso = new Date().toISOString()
+    const legacyData = parseLegacyStoredData(localStorage.getItem(STORAGE_KEY), fallbackYear)
+    const storedRegistry = parseRegistry(localStorage.getItem(REGISTRY_STORAGE_KEY), fallbackYear)
 
-        if (parsedData.dateCells) {
-          const dateCellsMap = new Map(Object.entries(parsedData.dateCells))
-          setDateCellsState(dateCellsMap)
-        }
-
-        if (parsedData.selectedColorTexture) {
-          setSelectedColorTextureState(parsedData.selectedColorTexture)
-        }
-
-        if (parsedData.selectedView && ["Linear", "Classic", "Column"].includes(parsedData.selectedView)) {
-          setSelectedViewState(parsedData.selectedView)
+    let registry = storedRegistry
+    if (!registry) {
+      const localId = generateCalendarId()
+      const baseData = legacyData ?? normalizeStoredData(null, fallbackYear)
+      registry = {
+        currentId: localId,
+        localId,
+        calendars: {
+          [localId]: {
+            id: localId,
+            data: baseData,
+            external: false,
+            lastUpdated: nowIso,
+          },
+        },
+      }
+    } else {
+      if (!registry.calendars[registry.localId]) {
+        const baseData = legacyData ?? normalizeStoredData(null, fallbackYear)
+        registry.calendars[registry.localId] = {
+          id: registry.localId,
+          data: baseData,
+          external: false,
+          lastUpdated: nowIso,
         }
       }
-    } catch (error) {
-      console.error("Error loading calendar data from localStorage:", error)
     }
+
+    const sharedCalendar = parseSharedCalendarFromUrl(fallbackYear)
+    if (sharedCalendar) {
+      registry.calendars[sharedCalendar.id] = {
+        id: sharedCalendar.id,
+        data: sharedCalendar.data,
+        external: sharedCalendar.id !== registry.localId,
+        lastUpdated: nowIso,
+      }
+      registry.currentId = sharedCalendar.id
+
+      try {
+        const url = new URL(window.location.href)
+        url.searchParams.set("calendar", sharedCalendar.id)
+        url.searchParams.delete("data")
+        window.history.replaceState({}, "", url.toString())
+      } catch (error) {
+        console.error("Failed to clean shared calendar URL parameters:", error)
+      }
+    } else {
+      const requestedId = readCalendarIdFromUrl()
+      if (requestedId && registry.calendars[requestedId]) {
+        registry.currentId = requestedId
+      } else if (!registry.currentId || !registry.calendars[registry.currentId]) {
+        registry.currentId = registry.localId
+      }
+    }
+
+    registryRef.current = registry
+
+    const activeEntry =
+      registry.calendars[registry.currentId] ?? registry.calendars[registry.localId]
+
+    const normalizedActive = normalizeStoredData(activeEntry?.data, fallbackYear)
+    setMonthRangeState(normalizedActive.monthRange)
+    setDateCellsState(new Map(Object.entries(normalizedActive.dateCells ?? {})))
+    setSelectedColorTextureState(normalizedActive.selectedColorTexture)
+    setSelectedViewState(normalizedActive.selectedView)
+    setCurrentCalendarId(registry.currentId)
+    setAvailableCalendars(buildSummaries(registry, registry.currentId))
+
+    try {
+      localStorage.setItem(REGISTRY_STORAGE_KEY, JSON.stringify(registry))
+    } catch (error) {
+      console.error("Error saving calendar registry to localStorage:", error)
+    }
+
+    const localEntry = registry.calendars[registry.localId]
+    if (localEntry) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(localEntry.data))
+      } catch (error) {
+        console.error("Error saving primary calendar data to localStorage:", error)
+      }
+    }
+
+    setIsInitialized(true)
   }, [currentYear])
 
-  const saveToLocalStorage = (overrides: Partial<StoredData> = {}) => {
-    const dataToSave: StoredData = {
-      monthRange,
+  const persistRegistry = (registry: CalendarRegistry, activeId: string) => {
+    registryRef.current = registry
+    setAvailableCalendars(buildSummaries(registry, activeId))
+
+    try {
+      localStorage.setItem(REGISTRY_STORAGE_KEY, JSON.stringify(registry))
+    } catch (error) {
+      console.error("Error persisting calendar registry:", error)
+    }
+
+    const localEntry = registry.calendars[registry.localId]
+    if (localEntry) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(localEntry.data))
+      } catch (error) {
+        console.error("Error saving local calendar snapshot:", error)
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (!isInitialized) return
+    if (!currentCalendarId) return
+
+    const registry = registryRef.current
+    if (!registry) return
+
+    const snapshot: StoredData = {
+      monthRange: ensureValidRange(monthRange),
       dateCells: Object.fromEntries(dateCells),
       selectedColorTexture,
       selectedView,
       version: STORAGE_VERSION,
-      ...overrides,
     }
 
-    dataToSave.version = STORAGE_VERSION
-
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(dataToSave))
-    } catch (error) {
-      console.error("Error saving calendar data to localStorage:", error)
+    const existingEntry = registry.calendars[currentCalendarId]
+    const updatedEntry: CalendarEntry = {
+      id: currentCalendarId,
+      data: snapshot,
+      external: currentCalendarId !== registry.localId ? existingEntry?.external ?? true : false,
+      lastUpdated: new Date().toISOString(),
     }
-  }
+
+    const updatedRegistry: CalendarRegistry = {
+      ...registry,
+      currentId: currentCalendarId,
+      calendars: {
+        ...registry.calendars,
+        [currentCalendarId]: updatedEntry,
+      },
+    }
+
+    persistRegistry(updatedRegistry, currentCalendarId)
+  }, [monthRange, dateCells, selectedColorTexture, selectedView, currentCalendarId, isInitialized])
 
   const setMonthRange = (range: MonthRange) => {
-    const validRange = ensureValidRange(range)
-    setMonthRangeState(validRange)
-    saveToLocalStorage({ monthRange: validRange })
+    setMonthRangeState(ensureValidRange(range))
   }
 
   const setDateCells = (newDateCells: Map<string, DateCellData>) => {
-    setDateCellsState(newDateCells)
-    saveToLocalStorage({ dateCells: Object.fromEntries(newDateCells) })
+    setDateCellsState(new Map(newDateCells))
   }
 
   const setSelectedColorTexture = (colorTexture: ColorTextureCode) => {
     setSelectedColorTextureState(colorTexture)
-    saveToLocalStorage({ selectedColorTexture: colorTexture })
   }
 
   const setSelectedView = (view: CalendarView) => {
     setSelectedViewState(view)
-    saveToLocalStorage({ selectedView: view })
+  }
+
+  const switchCalendar = (calendarId: string) => {
+    const registry = registryRef.current
+    if (!registry) return
+    const targetEntry = registry.calendars[calendarId]
+    if (!targetEntry) return
+
+    const normalized = normalizeStoredData(targetEntry.data, monthRange.start.year)
+    const nextRegistry: CalendarRegistry = {
+      ...registry,
+      currentId: calendarId,
+    }
+    registryRef.current = nextRegistry
+
+    setMonthRangeState(normalized.monthRange)
+    setDateCellsState(new Map(Object.entries(normalized.dateCells ?? {})))
+    setSelectedColorTextureState(normalized.selectedColorTexture)
+    setSelectedViewState(normalized.selectedView)
+    setCurrentCalendarId(calendarId)
+    setAvailableCalendars(buildSummaries(nextRegistry, calendarId))
+
+    try {
+      const url = new URL(window.location.href)
+      url.searchParams.set("calendar", calendarId)
+      url.searchParams.delete("data")
+      window.history.replaceState({}, "", url.toString())
+    } catch (error) {
+      console.error("Failed to update calendar id in URL:", error)
+    }
+  }
+
+  const getCurrentDataSnapshot = (): StoredData | null => {
+    if (!currentCalendarId) return null
+    return {
+      monthRange: ensureValidRange(monthRange),
+      dateCells: Object.fromEntries(dateCells),
+      selectedColorTexture,
+      selectedView,
+      version: STORAGE_VERSION,
+    }
   }
 
   const value: CalendarContextType = {
@@ -127,6 +437,11 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children }) 
     setSelectedColorTexture,
     selectedView,
     setSelectedView,
+    currentCalendarId,
+    availableCalendars,
+    switchCalendar,
+    isInitialized,
+    getCurrentDataSnapshot,
   }
 
   return <CalendarContext.Provider value={value}>{children}</CalendarContext.Provider>

--- a/src/utils/shareEncoding.ts
+++ b/src/utils/shareEncoding.ts
@@ -1,0 +1,54 @@
+const BASE64_URL_SAFE_CHARS = { '/': '_', '+': '-', '=': '' } as const
+
+const toBase64Url = (input: string): string => {
+  return input.replace(/[+/=]/g, (char) => BASE64_URL_SAFE_CHARS[char as keyof typeof BASE64_URL_SAFE_CHARS])
+}
+
+const fromBase64Url = (input: string): string => {
+  let base64 = input.replace(/-/g, "+").replace(/_/g, "/")
+  const padding = base64.length % 4
+  if (padding) {
+    base64 += "=".repeat(4 - padding)
+  }
+  return base64
+}
+
+const uint8ArrayToBase64 = (bytes: Uint8Array): string => {
+  let binary = ""
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    let chunkString = ""
+    for (let j = 0; j < chunk.length; j++) {
+      chunkString += String.fromCharCode(chunk[j])
+    }
+    binary += chunkString
+  }
+  return btoa(binary)
+}
+
+const base64ToUint8Array = (base64: string): Uint8Array => {
+  const binary = atob(base64)
+  const length = binary.length
+  const bytes = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+export const encodeCalendarPayload = (payload: unknown): string => {
+  const json = JSON.stringify(payload)
+  const encoder = new TextEncoder()
+  const bytes = encoder.encode(json)
+  const base64 = uint8ArrayToBase64(bytes)
+  return toBase64Url(base64)
+}
+
+export const decodeCalendarPayload = (encoded: string): unknown => {
+  const base64 = fromBase64Url(encoded)
+  const bytes = base64ToUint8Array(base64)
+  const decoder = new TextDecoder()
+  const json = decoder.decode(bytes)
+  return JSON.parse(json)
+}


### PR DESCRIPTION
## Summary
- add calendar sharing controls with copyable share link and calendar selector
- persist calendars with generated ids and registry so multiple calendars can be stored locally
- compress calendar data for URLs with custom base64 encoder and update save/load flow to rely on context state